### PR TITLE
Grants page

### DIFF
--- a/src/components/GrantRow.js
+++ b/src/components/GrantRow.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import numeral from 'numeral';
 
-import { slugify } from '../utils';
+import { slugify, dollarsFormatter } from '../utils';
 
 const GrantRow = ({ amount, description, org, orgUuid, summary, years, uuid }) => {
   let name = description;
@@ -16,7 +15,7 @@ const GrantRow = ({ amount, description, org, orgUuid, summary, years, uuid }) =
     <tr className={summary ? 'summary' : ''}>
       <td>{name}</td>
       <td>{years}</td>
-      <td className="amount">{numeral(amount).format('0,0[.]00')}</td>
+      <td className="amount">{dollarsFormatter.format(amount)}</td>
     </tr>
   );
 };

--- a/src/components/GrantRow.js
+++ b/src/components/GrantRow.js
@@ -3,11 +3,15 @@ import numeral from 'numeral';
 
 import { slugify } from '../utils';
 
-const GrantRow = ({ amount, description, org, orgUuid, summary, years }) => {
+const GrantRow = ({ amount, description, org, orgUuid, summary, years, uuid }) => {
   let name = description;
+
   if (summary) {
-    name = <a href={`/organizations/${slugify(name)}/${orgUuid}`}>{org}</a>;
+    name = <strong><a href={`/organizations/${slugify(name)}/${orgUuid}`}>{org}</a></strong>;
+  } else if (uuid) {
+    name = <span>{name} <a href={`/grants/${uuid}`}>>></a></span>;
   }
+
   return (
     <tr className={summary ? 'summary' : ''}>
       <td>{name}</td>

--- a/src/components/GrantTable.js
+++ b/src/components/GrantTable.js
@@ -31,6 +31,7 @@ Grants.propTypes = {
   grants: PropTypes.array,
   sums: PropTypes.object.isRequired,
   verb: PropTypes.string.isRequired,
+  relatedGrants: PropTypes.bool,
 };
 
 export default Grants;

--- a/src/components/GrantTable.js
+++ b/src/components/GrantTable.js
@@ -4,12 +4,12 @@ import PropTypes from 'prop-types';
 import YearlySumsBarchart from './YearlySumsBarchart';
 import GrantRow from './GrantRow';
 
-const Grants = ({ verb, grants, sums }) => {
+const Grants = ({ relatedGrants, verb, grants, sums }) => {
   const label = verb === 'funded' ? 'Recipient' : 'Funder';
 
   return (
     <div>
-      {sums && <YearlySumsBarchart sums={sums} />}
+      {!relatedGrants ? sums && <YearlySumsBarchart sums={sums} /> : ``}
       <table className="grantsTable">
         <thead>
           <tr>

--- a/src/components/GrantTable.js
+++ b/src/components/GrantTable.js
@@ -29,7 +29,7 @@ const Grants = ({ relatedGrants, verb, grants, sums }) => {
 
 Grants.propTypes = {
   grants: PropTypes.array,
-  sums: PropTypes.object.isRequired,
+  sums: PropTypes.object,
   verb: PropTypes.string.isRequired,
   relatedGrants: PropTypes.bool,
 };

--- a/src/components/OrgFinances.js
+++ b/src/components/OrgFinances.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col } from 'react-bootstrap';
-import numeral from 'numeral';
+
+import { dollarsFormatter } from '../utils';
 
 const Amt = ({ value }) => (
-  <td className="amt">{numeral(value).format('0,0[.]00')}</td>
+  <td className="amt">{dollarsFormatter.format(value)}</td>
 );
 
 const OrgFinances = ({ forms990 }) => {

--- a/src/components/YearlySumsBarchart.js
+++ b/src/components/YearlySumsBarchart.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const formatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-});
+import { dollarsFormatter } from '../utils';
+
 
 const YearlySumsBarchart = ({ sums }) => {
   const data = Object.keys(sums).map((k, i) => ({
@@ -48,7 +46,7 @@ const YearlySumsBarchart = ({ sums }) => {
               height="25"
             ></rect>
             <text x="6" y={i * 25 + 12} fill="#fff" dy=".35em">
-              {d.label}: {formatter.format(d.value)}
+              {d.label}: {dollarsFormatter.format(d.value)}
             </text>
           </g>
         ))}

--- a/src/containers/Grants.js
+++ b/src/containers/Grants.js
@@ -133,8 +133,8 @@ const Grant = () => {
 
       <h2>Related grants</h2>
       <Nav bsStyle="tabs" activeKey={showGrantsRelated} onSelect={setGrantRelation}>
-        <NavItem eventKey="funded">From {from.name} ({from.countGrantsFrom})</NavItem>
-        <NavItem eventKey="received">To {to.name} ({to.countGrantsTo})</NavItem>
+        <NavItem eventKey="funded">From {from.name}</NavItem>
+        <NavItem eventKey="received">To {to.name}</NavItem>
       </Nav>
       <GrantTable
         relatedGrants

--- a/src/containers/Grants.js
+++ b/src/containers/Grants.js
@@ -28,10 +28,14 @@ const GET_GRANT = gql`
       from {
         name
         uuid
+        countGrantsFrom
+        totalFunded
       }
       to {
         name
         uuid
+        countGrantsTo
+        totalReceived
       }
     }
   }
@@ -42,7 +46,7 @@ export default () => {
 
   return (
     <div>
-      <h2>Grants</h2>
+      <h2>Grant</h2>
       <Switch>
         <Route path={`${match.path}/:grantId`}>
           <Grant />
@@ -65,14 +69,14 @@ const Grant = () => {
   if (loading) return 'Loading...';
   if (error) return `Error! ${error}`;
 
-  if (!data.grant) return `Oof!`;
+  if (!data.grant) return `Failed to load grant data!`;
 
   const { to, from, source } = data.grant;
   const { dateFrom, dateTo, amount, description } = cleanse(data.grant);
 
   return (
     <Page>
-      <Helmet title={grantId} />
+      <Helmet title={`Grant from ${from.name} to ${to.name}`} />
       <h1>{amount}</h1>
 
       <Row>

--- a/src/containers/Grants.js
+++ b/src/containers/Grants.js
@@ -9,7 +9,7 @@ import Helmet from 'react-helmet';
 
 import { Col, Row } from 'react-bootstrap';
 
-import { slugify, stripHtml, extractYear } from '../utils';
+import { slugify, stripHtml, extractYear, dollarsFormatter } from '../utils';
 
 import Page from '../components/Page';
 import Flag from '../components/Flag';
@@ -104,21 +104,13 @@ const Grant = () => {
 
 const cleanse = (grant) => {
   const dateFrom = extractYear(grant.dateFrom);
-
   const dateTo = extractYear(grant.dateTo);
-
-  const formatter = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 0,
-  });
-
   const desc = grant.description ? stripHtml(grant.description) : 'No description available';
 
   return {
     dateFrom,
     dateTo,
     description: desc,
-    amount: formatter.format(parseInt(grant.amount, 10)),
+    amount: dollarsFormatter.format(grant.amount),
   }
 };

--- a/src/containers/Grants.js
+++ b/src/containers/Grants.js
@@ -5,6 +5,17 @@ import { Switch, Route, useRouteMatch, useParams } from 'react-router-dom';
 import { gql } from 'apollo-boost';
 import { useQuery } from '@apollo/react-hooks';
 
+import Helmet from 'react-helmet';
+
+import { Col, Row } from 'react-bootstrap';
+
+import moment from 'moment';
+
+import { slugify } from '../utils';
+
+import Page from '../components/Page';
+import Flag from '../components/Flag';
+
 const GET_GRANT = gql`
   query grant($grantId: String!) {
     grant(uuid: $grantId) {
@@ -54,10 +65,62 @@ const Grant = () => {
   if (loading) return 'Loading...';
   if (error) return `Error! ${error}`;
 
+  if (!data.grant) return `Oof!`;
+
+  const { to, from, source } = data.grant;
+  const { dateFrom, dateTo, amount, description } = cleanse(data.grant);
+
   return (
-    <div>
-      <h3>Requested grant ID: {grantId}</h3>
-      <pre>{JSON.stringify(data)}</pre>
-    </div>
+    <Page>
+      <Helmet title={grantId} />
+      <h1>{amount}</h1>
+
+      <Row>
+        <Col md={6}>
+          From
+          <h2>
+            <a href={`/organizations/${slugify(from.name)}/${from.uuid}`}>{from.name}</a>
+          </h2>
+        </Col>
+        <Col md={6}>
+          To 
+          <h2>
+            <a href={`/organizations/${slugify(to.name)}/${to.uuid}`}>{to.name}</a>
+          </h2>
+        </Col>
+      </Row>
+      <p>From {dateFrom} to {dateTo}</p>
+
+      <p>{description}</p>
+      <p>Source {source}</p>
+      <Flag />
+
+      <p>**related grants table tbd**</p>
+    </Page>
   );
+};
+
+const cleanse = (grant) => {
+  const dateFrom = moment(
+    grant.dateFrom,
+    'ddd, DD MMM YYYY HH:mm:ss ZZ'
+  ).year();
+
+  const dateTo = moment(
+    grant.dateTo,
+    'ddd, DD MMM YYYY HH:mm:ss ZZ'
+  ).year();
+
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+  });
+
+  return {
+    dateFrom, 
+    dateTo,
+    description: grant.description || 'No description available.',
+    amount: formatter.format(parseInt(grant.amount, 10)),
+  }
 };

--- a/src/containers/Grants.js
+++ b/src/containers/Grants.js
@@ -121,10 +121,12 @@ const cleanse = (grant) => {
     minimumFractionDigits: 0,
   });
 
+  const desc = grant.description ? grant.description.replace(/<[^>]*>?/gm, '') : 'No description available';
+
   return {
     dateFrom, 
     dateTo,
-    description: grant.description || 'No description available.',
+    description: desc,
     amount: formatter.format(parseInt(grant.amount, 10)),
   }
 };

--- a/src/containers/Grants.js
+++ b/src/containers/Grants.js
@@ -9,9 +9,7 @@ import Helmet from 'react-helmet';
 
 import { Col, Row } from 'react-bootstrap';
 
-import moment from 'moment';
-
-import { slugify } from '../utils';
+import { slugify, stripHtml, extractYear } from '../utils';
 
 import Page from '../components/Page';
 import Flag from '../components/Flag';
@@ -105,15 +103,9 @@ const Grant = () => {
 };
 
 const cleanse = (grant) => {
-  const dateFrom = moment(
-    grant.dateFrom,
-    'ddd, DD MMM YYYY HH:mm:ss ZZ'
-  ).year();
+  const dateFrom = extractYear(grant.dateFrom);
 
-  const dateTo = moment(
-    grant.dateTo,
-    'ddd, DD MMM YYYY HH:mm:ss ZZ'
-  ).year();
+  const dateTo = extractYear(grant.dateTo);
 
   const formatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -121,10 +113,10 @@ const cleanse = (grant) => {
     minimumFractionDigits: 0,
   });
 
-  const desc = grant.description ? grant.description.replace(/<[^>]*>?/gm, '') : 'No description available';
+  const desc = grant.description ? stripHtml(grant.description) : 'No description available';
 
   return {
-    dateFrom, 
+    dateFrom,
     dateTo,
     description: desc,
     amount: formatter.format(parseInt(grant.amount, 10)),

--- a/src/containers/Organizations.js
+++ b/src/containers/Organizations.js
@@ -12,7 +12,7 @@ import Helmet from 'react-helmet';
 
 import { Col, Nav, NavItem, Row } from 'react-bootstrap';
 
-import { stripHtml, extractYear } from '../utils';
+import { stripHtml, extractYear, dollarsFormatter } from '../utils';
 
 import GrantTable from '../components/GrantTable';
 import OrgFinances from '../components/OrgFinances';
@@ -27,6 +27,8 @@ const GET_ORGANIZATION = gql`
       name
       description
       ein
+      totalFunded
+      totalReceived
       grantsFunded {
         uuid
         dateFrom
@@ -144,8 +146,8 @@ const Organization = () => {
       </p>
       <Flag />
       <Nav bsStyle="tabs" activeKey={showGrantSide} onSelect={setGrantSide}>
-        <NavItem eventKey="funded">Grants funded</NavItem>
-        <NavItem eventKey="received">Grants received</NavItem>
+        <NavItem eventKey="funded">Gave {dollarsFormatter.format(data.organization.totalFunded) || `$0`}</NavItem>
+        <NavItem eventKey="received">Received ${dollarsFormatter.format(data.organization.totalReceived) || `$0`}</NavItem>
       </Nav>
       <GrantTable
         verb={showGrantSide}

--- a/src/containers/Organizations.js
+++ b/src/containers/Organizations.js
@@ -12,6 +12,8 @@ import Helmet from 'react-helmet';
 
 import { Col, Nav, NavItem, Row } from 'react-bootstrap';
 
+import { stripHtml, extractYear } from '../utils';
+
 import GrantTable from '../components/GrantTable';
 import OrgFinances from '../components/OrgFinances';
 import OrgNteeLinks from '../components/OrgNteeLinks';
@@ -160,16 +162,10 @@ const cleanse = (organization) => {
   // Sort lists by org
   const flattenedGrantsReceived = sortBy(
     organization.grantsReceived.map((grant) => {
-      const dateFrom = moment(
-        grant.dateFrom,
-        'ddd, DD MMM YYYY HH:mm:ss ZZ'
-      ).year();
-      const dateTo = moment(
-        grant.dateTo,
-        'ddd, DD MMM YYYY HH:mm:ss ZZ'
-      ).year();
+      const dateFrom = extractYear(grant.dateFrom);
+      const dateTo = extractYear(grant.dateTo);
       const years = `${dateFrom} - ${dateTo}`;
-      const desc = grant.description ? grant.description.replace(/<[^>]*>?/gm, '') : 'No description available';
+      const desc = grant.description ? stripHtml(grant.description) : 'No description available';
 
       return {
         org: grant.from.name,
@@ -190,16 +186,10 @@ const cleanse = (organization) => {
 
   const flattenedGrantsFunded = sortBy(
     organization.grantsFunded.map((grant) => {
-      const dateFrom = moment(
-        grant.dateFrom,
-        'ddd, DD MMM YYYY HH:mm:ss ZZ'
-      ).year();
-      const dateTo = moment(
-        grant.dateTo,
-        'ddd, DD MMM YYYY HH:mm:ss ZZ'
-      ).year();
+      const dateFrom = extractYear(grant.dateFrom);
+      const dateTo = extractYear(grant.dateTo);
       const years = `${dateFrom} - ${dateTo}`;
-      const desc = grant.description ? grant.description.replace(/<[^>]*>?/gm, '') : 'No description available';
+      const desc = grant.description ? stripHtml(grant.description) : 'No description available';
 
       return {
         org: grant.to.name,

--- a/src/containers/Organizations.js
+++ b/src/containers/Organizations.js
@@ -164,7 +164,7 @@ const Organization = () => {
       <Flag />
       <Nav bsStyle="tabs" activeKey={showGrantSide} onSelect={setGrantSide}>
         <NavItem eventKey="funded">Gave {dollarsFormatter.format(data.organization.totalFunded) || `$0`}</NavItem>
-        <NavItem eventKey="received">Received ${dollarsFormatter.format(data.organization.totalReceived) || `$0`}</NavItem>
+        <NavItem eventKey="received">Received {dollarsFormatter.format(data.organization.totalReceived) || `$0`}</NavItem>
       </Nav>
       <GrantTable
         verb={showGrantSide}

--- a/src/containers/Organizations.js
+++ b/src/containers/Organizations.js
@@ -101,7 +101,7 @@ const Organization = () => {
   if (loading) return 'Loading...';
   if (error) return `Error! ${error}`;
 
-  if (!data.organization) return `Oof!`;
+  if (!data.organization) return `Failed to load org data!`;
 
   const { name, description, ein, nteeOrganizationTypes } = data.organization;
 
@@ -173,7 +173,7 @@ const cleanse = (organization) => {
       return {
         org: grant.from.name,
         orgUuid: grant.from.uuid,
-        description: grant.description || 'n/a',
+        description: grant.description || 'No description available',
         amount: grant.amount,
         uuid: grant.uuid,
         dateFrom,
@@ -202,7 +202,7 @@ const cleanse = (organization) => {
       return {
         org: grant.to.name,
         orgUuid: grant.to.uuid,
-        description: grant.description || 'n/a',
+        description: grant.description || 'No description available',
         amount: grant.amount,
         uuid: grant.uuid,
         dateFrom,

--- a/src/containers/Organizations.js
+++ b/src/containers/Organizations.js
@@ -169,11 +169,12 @@ const cleanse = (organization) => {
         'ddd, DD MMM YYYY HH:mm:ss ZZ'
       ).year();
       const years = `${dateFrom} - ${dateTo}`;
+      const desc = grant.description ? grant.description.replace(/<[^>]*>?/gm, '') : 'No description available';
 
       return {
         org: grant.from.name,
         orgUuid: grant.from.uuid,
-        description: grant.description || 'No description available',
+        description: desc,
         amount: grant.amount,
         uuid: grant.uuid,
         dateFrom,
@@ -198,11 +199,12 @@ const cleanse = (organization) => {
         'ddd, DD MMM YYYY HH:mm:ss ZZ'
       ).year();
       const years = `${dateFrom} - ${dateTo}`;
+      const desc = grant.description ? grant.description.replace(/<[^>]*>?/gm, '') : 'No description available';
 
       return {
         org: grant.to.name,
         orgUuid: grant.to.uuid,
-        description: grant.description || 'No description available',
+        description: desc,
         amount: grant.amount,
         uuid: grant.uuid,
         dateFrom,

--- a/src/containers/Stats.js
+++ b/src/containers/Stats.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import numeral from 'numeral';
 
 import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
 
-import numeral from 'numeral';
+import { dollarsFormatter } from '../utils';
+
 
 // Graphql query using name as search parameter on irs organizations
 const GET_STATS = gql`
@@ -35,7 +37,7 @@ const Stats = ({ name }) => {
       Search <strong>{numeral(totalNumOrgs).format('0,0')}</strong>{' '}
       organizations and <strong>{numeral(totalNumGrants).format('0,0')}</strong>{' '}
       grants covering{' '}
-      <strong>{numeral(totalGrantsDollars).format('$0,0[.]00')}</strong> in
+      <strong>{dollarsFormatter.format(totalGrantsDollars)}</strong> in
       Detroit.
     </h2>
   );

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -17,4 +17,12 @@ export const extractYear = (dateString) =>
   moment(
     dateString,
     'ddd, DD MMM YYYY HH:mm:ss ZZ'
-  ).year()
+  ).year();
+
+
+export const dollarsFormatter =
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+  });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,20 @@
+import moment from 'moment';
+
+
 export const slugify = (string) =>
   string
     .toLowerCase()
     .replace(/ /g, '-')
     .replace(/[-]+/g, '-')
     .replace(/[^\w-]+/g, '');
+
+
+export const stripHtml = (string) => 
+  string.replace(/<[^>]*>?/gm, '');
+
+
+export const extractYear = (dateString) => 
+  moment(
+    dateString,
+    'ddd, DD MMM YYYY HH:mm:ss ZZ'
+  ).year()


### PR DESCRIPTION
- [x] Pages for individual grants (#20)

Changes:
- From grants table on an organization page, link each grant description to individual grant page
- Basic grant page layout
- Extend GrantTable component to support related grants (don't show yearly sums bar charts for related grants)
- Format and clean up content (strip hmtl from grant descriptions, only show year of grant dates, consistent display of $, etc)
