### PR TITLE
Allow absolute imports

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src"
+  },
+  "include": ["src"]
+}

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import Helmet from 'react-helmet';
 
-import Page from '../components/Page';
-import Search from './Search';
-import Stats from './Stats';
+import Page from 'components/Page';
+import Search from 'containers/Search';
+import Stats from 'containers/Stats';
 
 export default function Index() {
   return (


### PR DESCRIPTION
This is one of my favorite QOL improvements: https://create-react-app.dev/docs/importing-a-component/#absolute-imports

It allows us to use absolute imports from the `src` folder (or whatever folder we designate) instead of having to use relative imports. That makes it easier to move components around and removes the need to guess where in the folder hierarchy you are relative to your desired import